### PR TITLE
Fix handling of infinite tolerance

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -147,7 +147,7 @@ impl Constraints {
 
     fn inside_bounds(angle1: f64, angle2: f64, tolerance: f64) -> bool {
         if tolerance.is_infinite() {
-            return false;
+            return true;
         }
         let mut difference = (angle1 - angle2).abs();
         difference = difference % TWO_PI;

--- a/src/tests/constraint_test.rs
+++ b/src/tests/constraint_test.rs
@@ -71,4 +71,22 @@ mod tests {
             panic!("Solutions do not match");
         }
     }
+
+    #[test]
+    fn test_no_limits_accept_all_angles() {
+        // from == to for each joint means no limits (tolerance is infinity)
+        let from = [0.0; 6];
+        let to = [0.0; 6];
+        let constraints = Constraints::new(from, to, BY_CONSTRAINS);
+
+        let samples = [
+            [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+            [std::f64::consts::PI, -std::f64::consts::PI, 2.0 * std::f64::consts::PI,
+             -2.0 * std::f64::consts::PI, 1.5 * std::f64::consts::PI, -1.5 * std::f64::consts::PI],
+        ];
+
+        for angles in samples.iter() {
+            assert!(constraints.compliant(angles));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- ensure `inside_bounds` returns true for infinite tolerances
- verify no-limit constraints accept any angles

## Testing
- `cargo build`
- `cargo test` *(fails: linking with `cc` failed)*
- `cargo test --lib`
- `cargo test --no-default-features`


------
https://chatgpt.com/codex/tasks/task_e_687a61ccb21c832c8c00719a7d2b8637