### PR TITLE
Add sign correction default test

### DIFF
--- a/src/parameters_from_file.rs
+++ b/src/parameters_from_file.rs
@@ -66,10 +66,10 @@ impl Parameters {
 
 
     fn read_sign_corrections(doc: &Yaml) -> Result<[i8; 6], ParameterError> {
-        // Store the temporary vector in a variable for longer lifetime
+        // Store the default sign corrections (all ones) for longer lifetime
         let default_sign_corrections = vec![Yaml::Integer(1); 6];
 
-        // Check if the sign corrections field exists, if not default to all 0
+        // Check if the sign corrections field exists, if not default to all 1
         let sign_corrections_yaml = doc.as_vec().unwrap_or(&default_sign_corrections);
 
         let mut sign_corrections: Vec<i8> = sign_corrections_yaml

--- a/src/tests/data/fanuc/fanuc_m16ib20_no_sign.yaml
+++ b/src/tests/data/fanuc/fanuc_m16ib20_no_sign.yaml
@@ -1,0 +1,12 @@
+#
+# Test data set for Fanuc m16ib20 without sign corrections
+#
+opw_kinematics_geometric_parameters:
+  a1: 0.15
+  a2: -0.10
+  b: 0.0
+  c1: 0.525
+  c2: 0.77
+  c3: 0.74
+  c4: 0.10
+opw_kinematics_joint_offsets: [0, 0, deg(-90), 0, 0, deg(180)]

--- a/src/tests/test_from_yaml.rs
+++ b/src/tests/test_from_yaml.rs
@@ -67,4 +67,27 @@ mod tests {
         assert_eq!(expected.sign_corrections, loaded.sign_corrections);
         assert_eq!(expected.dof, loaded.dof);
     }
+
+    #[test]
+    fn test_parameters_from_yaml_missing_sign_corrections() {
+        let filename = "src/tests/data/fanuc/fanuc_m16ib20_no_sign.yaml";
+        let loaded =
+            Parameters::from_yaml_file(filename).expect(READ_ERROR);
+
+        let expected = Parameters {
+            a1: 0.15,
+            a2: -0.10,
+            b: 0.0,
+            c1: 0.525,
+            c2: 0.77,
+            c3: 0.74,
+            c4: 0.10,
+            offsets: [0.0, 0.0, -90.0_f64.to_radians(), 0.0, 0.0, 180.0_f64.to_radians()],
+            sign_corrections: [1, 1, 1, 1, 1, 1],
+            dof: 6,
+        };
+
+        assert_eq!(expected.sign_corrections, loaded.sign_corrections);
+        assert_eq!(expected.dof, loaded.dof);
+    }
 }


### PR DESCRIPTION
## Summary
- clarify comment about default sign corrections
- add YAML data missing sign corrections
- test Parameters::from_yaml_file when sign corrections are missing

## Testing
- `cargo build`
- `cargo test -- --color never`

------
https://chatgpt.com/codex/tasks/task_e_687a61a347e8832c9f856a84d1d22806