### PR TITLE
Fix version constant

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-const VERSION: &str = "1.8.5";
+const VERSION: &str = "1.8.9";
 
 #[cfg(feature = "allow_filesystem")]
 fn main() {


### PR DESCRIPTION
## Summary
- update `VERSION` constant to `1.8.9` in `src/main.rs`

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687a60b5a6a4832ca084ddcfe0d15c9a