### PR TITLE
Fix version constant

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-const VERSION: &str = "1.3.0";
+/// Package version derived at compile time from `Cargo.toml`.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(feature = "allow_filesystem")]
 fn main() {


### PR DESCRIPTION
## Summary
- ensure the CLI version matches `Cargo.toml`
- use `env!("CARGO_PKG_VERSION")` so the constant stays in sync

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687ab6985724832c8e03707e6f2ad6d0