### PR TITLE
Fix helper placement

### DIFF
--- a/src/urdf.rs
+++ b/src/urdf.rs
@@ -385,6 +385,15 @@ fn populate_opw_parameters(joint_map: HashMap<String, JointData>, joint_names: &
     let names = joint_names.unwrap_or_else(
         || ["joint1", "joint2", "joint3", "joint4", "joint5", "joint6"]);
 
+    fn non_zero(a: f64, b: f64) -> Result<f64, String> {
+        match (a, b) {
+            (0.0, 0.0) => Ok(0.0), // assuming c2 = 0.0
+            (0.0, b) => Ok(b),
+            (a, 0.0) => Ok(a),
+            (_, _) => Err(String::from("Both potential c2 values are non-zero")),
+        }
+    }
+
     for j in 0..6 {
         let joint = joint_map
             .get(names[j]).ok_or_else(|| format!("Joint {} not found: {}", j, names[j]))?;
@@ -410,16 +419,8 @@ fn populate_opw_parameters(joint_map: HashMap<String, JointData>, joint_names: &
                         opw_parameters.b = 0.0;
                     }
                     Err(_err) => {
-                        pub fn non_zero(a: f64, b: f64) -> Result<f64, String> {
-                            match (a, b) {
-                                (0.0, 0.0) => Ok(0.0), // assuming c2 = 0.0
-                                (0.0, b) => Ok(b),
-                                (a, 0.0) => Ok(a),
-                                (_, _) => Err(String::from("Both potential c2 values are non-zero")),
-                            }
-                        }
                         // If there are multiple values, we assume b is given here as y.
-                        // c2 is given either in z or in x, other being 0. 
+                        // c2 is given either in z or in x, other being 0.
                         opw_parameters.c2 = non_zero(joint.vector.x, joint.vector.z)?;
                         opw_parameters.b = joint.vector.y;
                     }
@@ -431,14 +432,6 @@ fn populate_opw_parameters(joint_map: HashMap<String, JointData>, joint_names: &
                         opw_parameters.a2 = -value;
                     }
                     Err(_err) => {
-                        pub fn non_zero(a: f64, b: f64) -> Result<f64, String> {
-                            match (a, b) {
-                                (0.0, 0.0) => Ok(0.0), // assuming c2 = 0.0
-                                (0.0, b) => Ok(b),
-                                (a, 0.0) => Ok(a),
-                                (_, _) => Err(String::from("Both potential c2 values are non-zero")),
-                            }
-                        }
                         // If there are multiple values, we assume a2 is given here as z.
                         // c3 is given either in y or in x, other being 0.
                         opw_parameters.a2 = -joint.vector.z;


### PR DESCRIPTION
## Summary
- move `non_zero` helper in `populate_opw_parameters`
- reuse it for both match branches

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687ab69350fc832c8bda2290a2af3ce8