### PR TITLE
Fix typos in wrap-around comments

### DIFF
--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -36,7 +36,7 @@ const TWO_PI: f64 = 2.0 * PI;
 
 impl Constraints {
     /// Create constraints that restrict the joint rotations between 'from' to 'to' values.
-    /// Wrapping arround is supported so order is important. For instance,
+    /// Wrapping around is supported so order is important. For instance,
     /// from = 0.1 and to = 0.2 (radians) means the joint
     /// is allowed to rotate to 0.11, 0.12 ... 1.99, 0.2. 
     /// from = 0.2 ant to = 0.1 is also valid but means the joint is allowed to rotate
@@ -67,11 +67,11 @@ impl Constraints {
             if a == b {
                 tolerances[j_idx] = INFINITY; // No constraint, not checked
             } else if a < b {
-                // Values do not wrap arround
+                // Values do not wrap around
                 centers[j_idx] = (a + b) / 2.0;
                 tolerances[j_idx] = (b - a) / 2.0;
             } else {
-                // Values wrap arround. Move b forward by period till it gets ahead.
+                // Values wrap around. Move b forward by period till it gets ahead.
                 while b < a {
                     b = b + TWO_PI;
                 }

--- a/src/tests/constraint_test_various.rs
+++ b/src/tests/constraint_test_various.rs
@@ -60,7 +60,7 @@ mod tests {
                     }
                 }
 
-                // Decide if we are doing the "wrap arround 360 or 0 case" or ordinary case
+                // Decide if we are doing the "wrap around 360 or 0 case" or ordinary case
                 if rng.gen_bool(0.5) {
                     expected_results[i] = pass;
                     from_angles[i] = a;


### PR DESCRIPTION
## Summary
- correct "arround" to "around" in comments for wrapping behaviour

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_687bca1b1db0832c8897888649662b7b