### PR TITLE
Implement Error for ParameterError

### DIFF
--- a/src/parameter_error.rs
+++ b/src/parameter_error.rs
@@ -43,3 +43,12 @@ impl From<io::Error> for ParameterError {
         ParameterError::IoError(err)
     }
 }
+
+impl std::error::Error for ParameterError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            ParameterError::IoError(err) => Some(err),
+            _ => None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- implement `std::error::Error` for `ParameterError`
- ensure build and tests succeed

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687bc9dd9504832cbd9fd59863ac4eee