### PR TITLE
Fix typos across project

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ It has less code receives all fixes and performance improvements from the latest
 - For kinematic singularity at J5 = 0&deg; or J5 = &plusmn;180&deg; positions this solver provides reasonable J4 and J6
   values close to the previous positions of these joints (and not arbitrary that may result in a large jerk of the real
   robot)
-- Jacobian, torgues and velocities
+- Jacobian, torques and velocities
 - The robot can be equipped with the tool and placed on the base, planning for the desired location and orientation
   of the tool center point (TCP) rather than any part of the robot.
 - Experimental support for parameter extraction from URDF.
@@ -96,7 +96,7 @@ on a [base](https://docs.rs/rs-opw-kinematics/1.3.7/rs_opw_kinematics/tool/struc
 "Robot with the tool" and "Robot on the base" can be constructed around any Kinematics trait, and implement the
 Kinematics trait themselves. It is possible to cascade them.
 
-# Jacobian: torgues and velocities
+# Jacobian: torques and velocities
 Please see the [example](examples/jacobian.rs).
 
 Since 1.3.4, it is possible to obtain the [Jacobian](https://docs.rs/rs-opw-kinematics/1.3.7/rs_opw_kinematics/jacobian/struct.Jacobian.html) that represents the relationship between the joint velocities
@@ -105,11 +105,11 @@ and the end-effector velocities. The computed Jacobian object provides:
 - Joint [torques](https://docs.rs/rs-opw-kinematics/1.3.7/rs_opw_kinematics/jacobian/struct.Jacobian.html#method.torques) required to achieve a desired end-effector force/torque.
 
 The same Joints structure is reused, the six values now representing either angular velocities in radians per second
-or torgues in Newton meters. For the end effector, it is possible to use either nalgebra Isometry3 or Vector6,
+or torques in Newton meters. For the end effector, it is possible to use either nalgebra Isometry3 or Vector6,
 both defining velocities in m/s or rotations in N m.
 
 These values are useful when path planning for a robot that needs to move very swiftly, to prevent
-overspeed or overtorgue of individual joints.
+overspeed or overtorque of individual joints.
 
 
 # Example
@@ -168,7 +168,7 @@ fn main() {
             BY_PREV,
         ));
 
-    println!("If we do not have the previous pose yet, we can now ask to prever the pose \
+    println!("If we do not have the previous pose yet, we can now ask to prefer the pose \
     closer to the center of constraints.");
     let solutions = robot.inverse_continuing(&pose, &CONSTRAINT_CENTERED);
     dump_solutions(&solutions);

--- a/examples/constraints.rs
+++ b/examples/constraints.rs
@@ -32,7 +32,7 @@ fn main() {
     let pose: Pose = robot.forward(&joints); // Pose is alias of nalgebra::Isometry3<f64>
 
     println!(
-        "If we do not have the previous pose yet, we can now ask to prever the pose \
+        "If we do not have the previous pose yet, we can now ask to prefer the pose \
     closer to the center of constraints."
     );
     let solutions = robot.inverse_continuing(&pose, &CONSTRAINT_CENTERED);

--- a/src/constraints.rs
+++ b/src/constraints.rs
@@ -36,10 +36,10 @@ const TWO_PI: f64 = 2.0 * PI;
 
 impl Constraints {
     /// Create constraints that restrict the joint rotations between 'from' to 'to' values.
-    /// Wrapping arround is supported so order is important. For instance,
+    /// Wrapping around is supported so order is important. For instance,
     /// from = 0.1 and to = 0.2 (radians) means the joint
     /// is allowed to rotate to 0.11, 0.12 ... 1.99, 0.2. 
-    /// from = 0.2 ant to = 0.1 is also valid but means the joint is allowed to rotate
+    /// from = 0.2 and to = 0.1 is also valid but means the joint is allowed to rotate
     /// to 0.21, 0.22, 0.99, 2 * PI or 0.0 (wrapping around), then to 0.09 and finally 0.1,
     /// so the other side of the circle. The sorting_weight parameter influences sorting of the
     /// results: 0.0 (or BY_PREV) gives absolute priority to the previous values of the joints,
@@ -67,11 +67,11 @@ impl Constraints {
             if a == b {
                 tolerances[j_idx] = INFINITY; // No constraint, not checked
             } else if a < b {
-                // Values do not wrap arround
+                // Values do not wrap around
                 centers[j_idx] = (a + b) / 2.0;
                 tolerances[j_idx] = (b - a) / 2.0;
             } else {
-                // Values wrap arround. Move b forward by period till it gets ahead.
+                // Values wrap around. Move b forward by period till it gets ahead.
                 while b < a {
                     b = b + TWO_PI;
                 }

--- a/src/jacobian.rs
+++ b/src/jacobian.rs
@@ -24,7 +24,7 @@ use crate::kinematic_traits::{Joints, Kinematics};
 use crate::utils::vector6_to_joints;
 
 /// This structure holds Jacobian matrix and provides methods to
-/// extract velocity and torgue information from it.
+/// extract velocity and torque information from it.
 ///
 ///
 ///  This package provides support for the Jacobian matrix.
@@ -188,7 +188,7 @@ impl Jacobian {
     ///
     /// # Arguments
     ///
-    /// * `desired_force_torque` - isometry structure representing forces (in Newtons, N) and torgues
+    /// * `desired_force_torque` - isometry structure representing forces (in Newtons, N) and torques
     ///                            (in Newton - meters, Nm) rather than dimensions and angles.
     ///
     /// # Returns
@@ -199,15 +199,15 @@ impl Jacobian {
 
         // Extract the linear velocity (translation) and angular velocity (rotation)
         let linear_force = desired_force_isometry.translation.vector;
-        let angular_torgue = desired_force_isometry.rotation.scaled_axis();
+        let angular_torque = desired_force_isometry.rotation.scaled_axis();
 
         // Combine into a single 6D vector
-        let desired_force_torgue_vector = Vector6::new(
+        let desired_force_torque_vector = Vector6::new(
             linear_force.x, linear_force.y, linear_force.z,
-            angular_torgue.x, angular_torgue.y, angular_torgue.z,
+            angular_torque.x, angular_torque.y, angular_torque.z,
         );
 
-        let joint_torques = self.matrix.transpose() * desired_force_torgue_vector;
+        let joint_torques = self.matrix.transpose() * desired_force_torque_vector;
         vector6_to_joints(joint_torques)
     }
 
@@ -216,7 +216,7 @@ impl Jacobian {
     ///
     /// t = JᵀF
     ///
-    /// where Jᵀ is transposed Jacobian as defined above and f is the desired force and torgue
+    /// where Jᵀ is transposed Jacobian as defined above and f is the desired force and torque
     /// vector. The first 3 components are forces along x, y and z in Newtons, the other 3
     /// components are rotations around x (roll), y (pitch) and z (yaw) axis in Newton meters.
     ///
@@ -402,7 +402,7 @@ mod tests {
         let initial_qs = [0.0; 6];
         let jacobian = Jacobian::new(&robot, &initial_qs, EPSILON);
 
-        // For a single joint robot, that we want on the torgue is what we need to put
+        // For a single joint robot, the torque we want is what we need to put
         let desired_force_torque =
             Isometry3::new(Vector3::new(0.0, 0.0, 0.0),
                            Vector3::new(0.0, 0.0, 1.234));

--- a/src/tests/constraint_test_various.rs
+++ b/src/tests/constraint_test_various.rs
@@ -212,7 +212,7 @@ mod tests {
         );
         let actual = constraints.compliant(&as_radians(case.check_angles));
         if actual != case.passing {
-            println!("Case mimatch: expected {}, actual {}", case.passing, actual);
+            println!("Case mismatch: expected {}, actual {}", case.passing, actual);
             println!("ID: {}, From: {:?}, To: {:?}, Check: {:?}, Result: {:?} Passing {:?}",
                      case.id, case.from_angles, case.to_angles, case.check_angles,
                      case.expected_results, case.passing);

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub(crate) mod opw_kinematics {
     }
 }
 
-/// Print joint values for all solutions, converting radianst to degrees.
+/// Print joint values for all solutions, converting radians to degrees.
 #[allow(dead_code)]
 pub fn dump_solutions(solutions: &Solutions) {
     if solutions.is_empty() {
@@ -45,7 +45,7 @@ pub fn dump_solutions_degrees(solutions: &Solutions) {
     }
 }
 
-/// Print joint values, converting radianst to degrees.
+/// Print joint values, converting radians to degrees.
 #[allow(dead_code)]
 pub fn dump_joints(joints: &Joints) {
     let mut row_str = String::new();


### PR DESCRIPTION
## Summary
- fix "radianst" typo in utils
- correct spelling of "torque" in jacobian module and README
- use "prefer" wording in constraints example and README
- fix "mismatch" output in constraint tests
- clean up comments in constraints module

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_687bc9cc89d4832ca19555db5ce5168c