### PR TITLE
Fix comment typos

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,7 +14,7 @@ pub(crate) mod opw_kinematics {
     }
 }
 
-/// Print joint values for all solutions, converting radianst to degrees.
+/// Print joint values for all solutions, converting radians to degrees.
 #[allow(dead_code)]
 pub fn dump_solutions(solutions: &Solutions) {
     if solutions.is_empty() {
@@ -45,7 +45,7 @@ pub fn dump_solutions_degrees(solutions: &Solutions) {
     }
 }
 
-/// Print joint values, converting radianst to degrees.
+/// Print joint values, converting radians to degrees.
 #[allow(dead_code)]
 pub fn dump_joints(joints: &Joints) {
     let mut row_str = String::new();


### PR DESCRIPTION
## Summary
- fix typo 'radianst' -> 'radians' in utils comments

## Testing
- `cargo build --color=never`
- `cargo test --color=never`

------
https://chatgpt.com/codex/tasks/task_e_687bc9b242a4832cb9b481305b8c9aa5